### PR TITLE
Ensure download link appears after compression

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -285,7 +285,8 @@ function revealDownload(url){
   const emailNote = $("emailNote"); // id MUST be all lowercase in HTML
   if(!url || !dlLink || !dlSection) return;
   dlLink.href = url;
-  dlSection.style.display = "";
+  // Explicitly override CSS rule (#downloadSection {display:none})
+  dlSection.style.display = "block";
   if(emailNote) emailNote.style.display = "";
   setStep(3);
   setTextSafe($("progressNote"), "Complete");


### PR DESCRIPTION
## Summary
- Ensure download section becomes visible by overriding CSS `display:none` when compression finishes.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f52b22628832ebfd0b999e08814f6