### PR TITLE
style: show provider pricing matrix

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -235,15 +235,22 @@ header p{
 .info-card h2{
   margin: 0 0 10px; font-size: 16px; display:flex; align-items:center; gap:8px;
 }
+.pricing-table-wrapper{
+  width:100%;
+  overflow-x:auto;
+}
 .pricing-table{
   width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 10px;
-  border:1px solid var(--border); border-radius: 10px; overflow: hidden;
+  border:1px solid var(--border); border-radius: 10px; overflow: hidden; table-layout: fixed;
 }
 .pricing-table thead th{
-  background: var(--brand-soft); color: var(--brand-700); padding: 8px; border-bottom:1px solid #eadcff;
+  background: var(--brand-soft); color: var(--brand-700); padding: 8px; border-bottom:1px solid #eadcff; text-align:center;
 }
-.pricing-table td{
-  padding: 8px; border-top:1px solid var(--border);
+.pricing-table th, .pricing-table td{
+  padding: 8px; border-top:1px solid var(--border); text-align:center;
+}
+.pricing-table th:first-child, .pricing-table td:first-child{
+  text-align:left;
 }
 .pricing-table tr:nth-child(even) td{ background:#fafaff; }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -159,17 +159,39 @@
 
       <!-- Right card: Pricing (display only; JS updates the summary figures) -->
       <div class="info-card">
-        <h2><i class="fas fa-receipt"></i> Pricing Details (by uploaded size)</h2>
-        <table class="pricing-table">
-          <thead>
-            <tr><th>File size</th><th>Price</th></tr>
-          </thead>
-          <tbody>
-            <tr><td>0–500 MB</td><td>$1.99</td></tr>
-            <tr><td>501 MB–1 GB</td><td>$2.99</td></tr>
-            <tr><td>1.01–2 GB</td><td>$4.99</td></tr>
-          </tbody>
-        </table>
+        <h2><i class="fas fa-receipt"></i> Pricing Details</h2>
+        <div class="pricing-table-wrapper">
+          <table class="pricing-table">
+            <thead>
+              <tr>
+                <th>File size</th>
+                <th>Gmail</th>
+                <th>Outlook</th>
+                <th>Other</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>0–500 MB</td>
+                <td>$1.99</td>
+                <td>$2.19</td>
+                <td>$2.49</td>
+              </tr>
+              <tr>
+                <td>501 MB–1 GB</td>
+                <td>$2.99</td>
+                <td>$3.29</td>
+                <td>$3.99</td>
+              </tr>
+              <tr>
+                <td>1.01–2 GB</td>
+                <td>$4.49</td>
+                <td>$4.99</td>
+                <td>$5.49</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
         <!-- Summary numbers used by JS -->
         <div class="price-summary">


### PR DESCRIPTION
## Summary
- rename pricing section heading to "Pricing Details"
- show provider pricing matrix with sizes and costs
- wrap pricing table to keep layout contained

## Testing
- `make fmt` *(fails: E701 Multiple statements on one line (colon))*
- `make lint` *(fails: E701 Multiple statements on one line (colon))*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f56e8fb74832eb3811d40edbaf566