### PR TITLE
Fix missing Terms & Conditions route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -312,6 +312,13 @@ def index(request: Request):
     paid = request.query_params.get("paid") == "1"
     return template.render(adsense_tag=adsense_tag, paid=paid, job_id=job_id)
 
+
+@app.get("/terms", response_class=HTMLResponse)
+def terms() -> str:
+    """Serve the Terms & Conditions page."""
+    template = env.get_template("terms.html")
+    return template.render()
+
 # ------------ API ------------
 @app.post("/upload")
 async def upload(file: UploadFile = File(...), email: Optional[str] = Form(None)):


### PR DESCRIPTION
## Summary
- add `/terms` endpoint to serve Terms & Conditions page

## Testing
- `ruff check app/main.py` *(fails: E701 Multiple statements on one line)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f5e0fcc7c832e95a88f9cac444c14