### PR TITLE
Align navigation and repair contact page

### DIFF
--- a/app/templates/contact.html
+++ b/app/templates/contact.html
@@ -6,24 +6,26 @@
   <meta http-equiv="Cache-Control" content="no-store"/>
   <title>Contact Us – MailSized</title>
   <meta name="description" content="Contact MailSized. Get support, ask questions, or share feedback."/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
   <link rel="stylesheet" href="/static/style.css"/>
 </head>
 <body>
   <div class="container">
-    <!-- Top nav -->
-    <nav class="top-nav">
-      <a href="/">Home</a>
-      <a href="/how-it-works">How it Works</a>
-      <a href="/privacy">Privacy</a>
-      <strong>Contact Us</strong>
-    </nav>
-
     <header>
       <div class="logo">
         <div class="logo-icon"><i class="fas fa-video"></i></div>
         <h1>Contact Us</h1>
       </div>
       <p>We’d love to hear from you—support, feedback, or questions.</p>
+      <nav class="top-nav" aria-label="Main">
+        <a href="/" class="top-nav-link">Home</a>
+        <span class="sep">|</span>
+        <a href="/how-it-works" class="top-nav-link">How it Works</a>
+        <span class="sep">|</span>
+        <a href="/privacy" class="top-nav-link">Privacy</a>
+        <span class="sep">|</span>
+        <a href="/contact" class="top-nav-link">Contact Us</a>
+      </nav>
     </header>
 
     <div class="card-container">
@@ -71,7 +73,5 @@
     </div>
   </div>
 
-  <!-- Icons -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
 </body>
 </html>

--- a/app/templates/how-it-works.html
+++ b/app/templates/how-it-works.html
@@ -16,6 +16,7 @@
   <meta property="og:url" content="{{ PUBLIC_BASE_URL | default('https://mailsized.com') }}/how-it-works"/>
 
   <!-- Styles -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
   <link rel="stylesheet" href="/static/style.css"/>
 
   <!-- Structured data: Article + FAQPage -->
@@ -60,14 +61,6 @@
 <body>
   <div class="container">
 
-    <!-- Minimal top nav (inherits your styles; simple, left-aligned) -->
-    <nav class="top-nav" style="margin: 8px 0 10px;">
-      <a href="/" style="margin-right:16px;">Home</a>
-      <strong style="margin-right:16px;">How it Works</strong>
-      <a href="/blog" style="margin-right:16px;">Blogs</a>
-      <a href="/privacy">Privacy</a>
-    </nav>
-
     <header>
       <div class="logo">
         <div class="logo-icon"><i class="fas fa-video"></i></div>
@@ -79,6 +72,15 @@
         <div class="constraint"><i class="fas fa-check-circle"></i><span>Email-ready sizes</span></div>
         <div class="constraint"><i class="fas fa-bolt"></i><span>Fast turnaround</span></div>
       </div>
+      <nav class="top-nav" aria-label="Main">
+        <a href="/" class="top-nav-link">Home</a>
+        <span class="sep">|</span>
+        <a href="/how-it-works" class="top-nav-link">How it Works</a>
+        <span class="sep">|</span>
+        <a href="/privacy" class="top-nav-link">Privacy</a>
+        <span class="sep">|</span>
+        <a href="/contact" class="top-nav-link">Contact Us</a>
+      </nav>
     </header>
 
     <div class="card-container">
@@ -179,9 +181,6 @@
       </aside>
     </div>
   </div>
-
-  <!-- Icons (font awesome) – optional if already loaded on main -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
 
   <!-- Optional: load ads if configured -->
   <script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -33,7 +33,7 @@
           <span class="sep">|</span>
           <a href="/privacy" class="top-nav-link">Privacy</a>
           <span class="sep">|</span>
-          <a href="/blog" class="top-nav-link">Contact Us</a>        
+          <a href="/contact" class="top-nav-link">Contact Us</a>
       </nav>
       
     </header>

--- a/app/templates/privacy.html
+++ b/app/templates/privacy.html
@@ -34,9 +34,9 @@
         <span class="sep">|</span>
         <a href="/how-it-works" class="top-nav-link">How it Works</a>
         <span class="sep">|</span>
-        <a href="/blog" class="top-nav-link">Blogs</a>
-        <span class="sep">|</span>
         <a href="/privacy" class="top-nav-link">Privacy</a>
+        <span class="sep">|</span>
+        <a href="/contact" class="top-nav-link">Contact Us</a>
       </nav>
     </header>
 

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -4,11 +4,28 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Terms & Conditions – MailSized</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
   <link rel="stylesheet" href="/static/style.css"/>
 </head>
 <body>
   <div class="container">
-    <h1>Terms &amp; Conditions</h1>
+    <header>
+      <div class="logo">
+        <div class="logo-icon"><i class="fas fa-video"></i></div>
+        <h1>Terms &amp; Conditions</h1>
+      </div>
+      <nav class="top-nav" aria-label="Main">
+        <a href="/" class="top-nav-link">Home</a>
+        <span class="sep">|</span>
+        <a href="/how-it-works" class="top-nav-link">How it Works</a>
+        <span class="sep">|</span>
+        <a href="/privacy" class="top-nav-link">Privacy</a>
+        <span class="sep">|</span>
+        <a href="/contact" class="top-nav-link">Contact Us</a>
+      </nav>
+    </header>
+    <div class="card-container">
+      <div class="main-card">
     <p><strong>Effective Date:</strong> [Insert Date]</p>
 
     <p>Welcome to <strong>MailSized</strong> (“<strong>we</strong>”, “<strong>us</strong>”, “<strong>our</strong>”). These Terms &amp; Conditions (“<strong>Terms</strong>”) govern your access to and use of our website, apps, and related services (collectively, the “<strong>Service</strong>”). By using the Service, you agree to these Terms.</p>
@@ -85,6 +102,8 @@
     <p>Questions about these Terms? Contact: <strong>contact@mailsized.com</strong></p>
 
     <p style="margin-top:20px;font-size:12px;color:#6b7280;">Note: This document is a general template and not legal advice. Consider asking an attorney to review for your specific use case.</p>
+      </div>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Standardize top navigation across site templates
- Correct Contact Us link and embed nav within contact page header
- Add consistent header and navigation to terms and how-it-works pages

## Testing
- `make lint` *(fails: Module level import not at top of file, redefinition, unused imports)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0e533dae4832e8ca8b295c41b1367