### PR TITLE
Fix choose_target logic to avoid upscaling and respect provider case

### DIFF
--- a/tests/test_provider_targets.py
+++ b/tests/test_provider_targets.py
@@ -1,8 +1,19 @@
-from app.main import PROVIDER_TARGETS_MB
+from app.main import PROVIDER_TARGETS_MB, choose_target
 
 
 def test_provider_target_mapping():
     assert PROVIDER_TARGETS_MB["gmail"] == 25
     assert PROVIDER_TARGETS_MB["outlook"] == 20
     assert PROVIDER_TARGETS_MB["other"] == 15
+
+
+def test_choose_target_respects_original_size():
+    small = 5 * 1024 * 1024  # 5MB
+    assert choose_target("gmail", small) == small
+
+
+def test_choose_target_case_insensitive():
+    large = 30 * 1024 * 1024  # 30MB, above Gmail cap
+    expected = int((25 - 1.5) * 1024 * 1024)
+    assert choose_target("Gmail", large) == expected
 


### PR DESCRIPTION
## Summary
- handle provider names case-insensitively and prevent choose_target from enlarging small files
- add tests covering size preservation and case-insensitive provider handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1078513e0832ea5343fea303c60a5