### PR TITLE
Integrate AdSense and standardize ad slots

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -396,17 +396,16 @@ async def security_headers(request: Request, call_next):
 _RATE = {"tokens": {}, "capacity": 20, "refill": 20, "per": 60.0}  # generous defaults
 
 
+ADSENSE_CLIENT_ID = "ca-pub-7488512497606071"
+
+
 def _adsense_context() -> dict[str, str]:
-    """Return template variables for AdSense if enabled."""
-    tag = ""
-    client = ""
-    if os.environ.get("ENABLE_ADSENSE") == "1":
-        client = os.environ.get("ADSENSE_CLIENT_ID", "")
-        tag = (
-            f'<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={client}" '
-            'crossorigin="anonymous"></script>'
-        )
-    return {"adsense_tag": tag, "adsense_client_id": client}
+    """Return template variables for AdSense."""
+    tag = (
+        f'<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={ADSENSE_CLIENT_ID}" '
+        'crossorigin="anonymous"></script>'
+    )
+    return {"adsense_tag": tag, "adsense_client_id": ADSENSE_CLIENT_ID}
 
 
 @app.middleware("http")
@@ -462,16 +461,19 @@ def contact_get(request: Request):
     sent = request.query_params.get("sent") == "1"
     ctx = _adsense_context()
     return template.render(**ctx, sent=sent)
-    
+
+
 @app.get("/blogs", response_class=HTMLResponse)
 def blogs_index():
     template = env.get_template("blogs.html")
-    return template.render()
+    return template.render(**_adsense_context())
+
 
 @app.get("/blog/meet-mailsized", response_class=HTMLResponse)
 def blog_meet_mailsized():
     template = env.get_template("blog-meet-mailsized.html")
-    return template.render()
+    return template.render(**_adsense_context())
+
 
 @app.post("/contact")
 async def contact_post(

--- a/app/templates/how-it-works.html
+++ b/app/templates/how-it-works.html
@@ -130,11 +130,26 @@
           </tbody>
         </table>
         <p class="file-meta">Optional add-ons: Priority (+$0.75), Transcript (+$1.50). Tax calculated at checkout.</p>
-        <div id="ad-slot-sidebar" class="w-full rounded-2xl shadow-sm p-4 border bg-white" style="min-height:180px;margin-top:15px;" data-ad-slot="sidebar-300x250">
-          <div class="text-sm text-gray-500">Sponsored • placeholder</div>
+        <div id="ad-slot-sidebar" class="ad-slot" data-ad-slot="sidebar-300x250">
+          <div class="ad-placeholder">Sponsored • placeholder</div>
         </div>
       </aside>
     </div>
   </div>
+  <script>
+    if (window.adsbygoogle) {
+      const el = document.getElementById('ad-slot-sidebar');
+      if (el){
+        const ins = document.createElement('ins');
+        ins.className = 'adsbygoogle';
+        ins.style.display = 'block';
+        ins.setAttribute('data-ad-client', '{{ adsense_client_id }}');
+        ins.setAttribute('data-ad-slot', 'sidebar-300x250');
+        ins.setAttribute('data-full-width-responsive', 'true');
+        el.innerHTML = ''; el.appendChild(ins);
+        (adsbygoogle = window.adsbygoogle || []).push({});
+      }
+    }
+  </script>
 </body>
 </html>

--- a/app/templates/privacy.html
+++ b/app/templates/privacy.html
@@ -136,11 +136,26 @@
           <li>No selling of personal data.</li>
           <li>Security headers & short retention by design.</li>
         </ul>
-        <div id="ad-slot-sidebar" class="w-full rounded-2xl shadow-sm p-4 border bg-white" style="min-height:180px;margin-top:15px;" data-ad-slot="sidebar-300x250">
-          <div class="text-sm text-gray-500">Sponsored • placeholder</div>
+        <div id="ad-slot-sidebar" class="ad-slot" data-ad-slot="sidebar-300x250">
+          <div class="ad-placeholder">Sponsored • placeholder</div>
         </div>
       </aside>
     </div>
   </div>
+  <script>
+    if (window.adsbygoogle) {
+      const el = document.getElementById('ad-slot-sidebar');
+      if (el){
+        const ins = document.createElement('ins');
+        ins.className = 'adsbygoogle';
+        ins.style.display = 'block';
+        ins.setAttribute('data-ad-client', '{{ adsense_client_id }}');
+        ins.setAttribute('data-ad-slot', 'sidebar-300x250');
+        ins.setAttribute('data-full-width-responsive', 'true');
+        el.innerHTML = ''; el.appendChild(ins);
+        (adsbygoogle = window.adsbygoogle || []).push({});
+      }
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- always inject Google AdSense script with client id ca-pub-7488512497606071
- render AdSense context on blog pages and unify sidebar ad-slot styling
- add responsive ad initialization scripts to privacy and how-it-works pages

## Testing
- `ruff check app/main.py && black --check app/main.py`
- `make test`
- `make lint` *(fails: unused imports in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a128bc0338832e9edfbe17eed2d621