### PR TITLE
Handle contact form email asynchronously

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,16 @@ from typing import AsyncIterator, Dict, Optional, Tuple
 
 import requests
 import stripe
-from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile, Header
+from fastapi import (
+    BackgroundTasks,
+    FastAPI,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    UploadFile,
+    Header,
+)
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse, RedirectResponse
@@ -477,6 +486,7 @@ def blog_meet_mailsized():
 
 @app.post("/contact")
 async def contact_post(
+    background_tasks: BackgroundTasks,
     user_email: str = Form(...),
     subject: str = Form(...),
     message: str = Form(...),
@@ -485,7 +495,9 @@ async def contact_post(
         raise HTTPException(status_code=400, detail="Valid email required.")
     if not subject.strip() or not message.strip():
         raise HTTPException(status_code=400, detail="Subject and message are required.")
-    send_contact_message(user_email.strip(), subject.strip(), message.strip())
+    background_tasks.add_task(
+        send_contact_message, user_email.strip(), subject.strip(), message.strip()
+    )
     return RedirectResponse(url="/contact?sent=1", status_code=303)
 
 

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi.testclient import TestClient
+from app import main as app_module
+
+
+def test_contact_post_uses_background_tasks(monkeypatch):
+    recorded = {}
+
+    def fake_send(email, subject, message):
+        recorded['args'] = (email, subject, message)
+
+    monkeypatch.setattr(app_module, 'send_contact_message', fake_send)
+    client = TestClient(app_module.app)
+    resp = client.post(
+        '/contact',
+        data={'user_email': 'user@example.com', 'subject': 'Sub', 'message': 'Body'},
+        allow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert recorded['args'] == (
+        'user@example.com',
+        'Sub',
+        'Body'
+    )


### PR DESCRIPTION
## Summary
- send contact form emails via FastAPI BackgroundTasks to avoid request timeouts
- add regression test for contact form submission

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a1351c5518832e9466928c76da531f