### PR TITLE
Fix AdSense env flag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The application reads a number of environment variables to configure optional fe
 | `EMAIL_PASSWORD`        | Password for SMTP authentication (fallback)                    |
 | `SENDER_EMAIL`          | From address for outgoing emails (e.g. `contact@mailsized.com`)|
 | `DOWNLOAD_TTL_MIN`      | Minutes before a generated download link expires (default 30)   |
-| `ENABLE_ADSENSE`        | Set to `true` to activate AdSense; `false` disables ads         |
+| `ENABLE_ADSENSE`        | Set to `true`/`1` to activate AdSense; otherwise ads stay off   |
 | `ADSENSE_CLIENT_ID`     | Your Google AdSense client ID (e.g. `ca-pub-…`)                 |
 | `CONSENT_GIVEN`         | Indicates whether the user has consented to ad loading         |
 

--- a/app/main.py
+++ b/app/main.py
@@ -39,9 +39,15 @@ stripe.api_key = os.getenv("STRIPE_SECRET_KEY", "")
 STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
 OWNER_EMAIL = os.environ.get("OWNER_EMAIL", "")
 
+
+def _env_flag(name: str, default: str = "0") -> bool:
+    """Return True if the env var is one of several truthy values."""
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
 # Feature flags / ads
-ENABLE_RATE_LIMIT = os.getenv("ENABLE_RATE_LIMIT", "0") == "1"
-ENABLE_ADSENSE = os.getenv("ENABLE_ADSENSE", "1") == "1"  # default ON; safe if blocked
+ENABLE_RATE_LIMIT = _env_flag("ENABLE_RATE_LIMIT")
+ENABLE_ADSENSE = _env_flag("ENABLE_ADSENSE")
 ADSENSE_CLIENT_ID = os.getenv("ADSENSE_CLIENT_ID", "pub-7488512497606071")
 ADSENSE_SIDEBAR_SLOT = os.getenv("ADSENSE_SIDEBAR_SLOT", "5410433645")  # your numeric slot id
 

--- a/tests/test_env_flags.py
+++ b/tests/test_env_flags.py
@@ -1,0 +1,16 @@
+import os
+from app.main import _env_flag
+
+
+def test_env_flag_truthy(monkeypatch):
+    for val in ["1", "true", "TRUE", "yes", "on"]:
+        monkeypatch.setenv("MYFLAG", val)
+        assert _env_flag("MYFLAG") is True
+
+
+def test_env_flag_falsey(monkeypatch):
+    for val in ["0", "false", "no", "off", ""]:
+        monkeypatch.setenv("MYFLAG", val)
+        assert _env_flag("MYFLAG") is False
+    monkeypatch.delenv("MYFLAG", raising=False)
+    assert _env_flag("MYFLAG") is False


### PR DESCRIPTION
## Summary
- Allow env flags like ENABLE_ADSENSE to accept `1/true/yes/on` values and default to off
- Document AdSense flag usage in README
- Add tests covering the env flag helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1e1d54e60832e8b16228dd4e7b25e