### PR TITLE
Add resilient job start fallback for Stripe webhook

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -252,6 +252,20 @@
   </div>
 
   <!-- Core app JS always loads; do not couple to ads/analytics -->
+  <script>
+    // One-shot backup kick: if we returned from Stripe (paid=1),
+    // ask the server to start the job in case the webhook missed.
+    (function () {
+      try {
+        const root = document.getElementById('pageRoot');
+        const paid = root && root.dataset.paid === '1';
+        const jobId = root && root.dataset.jobId;
+        if (paid && jobId) {
+          fetch(`/start/${jobId}`, { method: 'POST' }).catch(() => {});
+        }
+      } catch (e) {}
+    })();
+  </script>
   <script defer src="/static/script.js?v=2025-08-14-7"></script>
 
   <!-- Defer ad rendering until idle; wrapped in try/catch; safe if blocked -->

--- a/tests/test_env_flags.py
+++ b/tests/test_env_flags.py
@@ -1,4 +1,3 @@
-import os
 from app.main import _env_flag
 
 


### PR DESCRIPTION
## Summary
- add resilient `_start_job_if_idle` helper to safely kick off queued jobs
- expose `/start/{job_id}` and make `/events/{job_id}` auto-start jobs as safety net
- add client-side script to nudge server after Stripe redirects
- remove unused import in tests

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1f52d0490832e89d2bef72f4f5c71