### PR TITLE
Add job status API with polling fallback and GA cleanup

### DIFF
--- a/app/templates/blog-meet-mailsized.html
+++ b/app/templates/blog-meet-mailsized.html
@@ -3,13 +3,6 @@
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5S8LF8NDE"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-S5S8LF8NDE');
-  </script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta http-equiv="Cache-Control" content="no-store"/>
@@ -32,7 +25,7 @@
   }
   </script>
 </head>
-<body>
+<body id="pageRoot" data-ga-id="G-S5S8LF8NDE">
   <div class="container">
     <!-- Top: logo + nav -->
     <header>
@@ -156,4 +149,5 @@
     </div>
   </div>
 </body>
+<script defer src="/static/script.js?v=2025-08-14-8"></script>
 </html>

--- a/app/templates/blogs.html
+++ b/app/templates/blogs.html
@@ -3,13 +3,6 @@
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5S8LF8NDE"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-S5S8LF8NDE');
-  </script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta http-equiv="Cache-Control" content="no-store"/>
@@ -19,7 +12,7 @@
   <link rel="stylesheet" href="/static/style.css"/>
   {{ adsense_tag|safe }}
 </head>
-<body>
+<body id="pageRoot" data-ga-id="G-S5S8LF8NDE">
   <div class="container">
     <!-- Top: logo + nav (matches your style) -->
     <header>
@@ -79,4 +72,5 @@
     </div>
   </div>
 </body>
+<script defer src="/static/script.js?v=2025-08-14-8"></script>
 </html>

--- a/app/templates/contact.html
+++ b/app/templates/contact.html
@@ -3,13 +3,6 @@
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5S8LF8NDE"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-S5S8LF8NDE');
-  </script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta http-equiv="Cache-Control" content="no-store"/>
@@ -20,7 +13,7 @@
 
   {{ adsense_tag|safe }}
 </head>
-<body>
+<body id="pageRoot" data-ga-id="G-S5S8LF8NDE">
   <div class="container">
     <header>
       <div class="logo">
@@ -104,4 +97,5 @@
     }
   </script>
 </body>
+<script defer src="/static/script.js?v=2025-08-14-8"></script>
 </html>

--- a/app/templates/how-it-works.html
+++ b/app/templates/how-it-works.html
@@ -4,13 +4,6 @@
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5S8LF8NDE"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-S5S8LF8NDE');
-  </script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta http-equiv="Cache-Control" content="no-store"/>
@@ -34,7 +27,7 @@
   }
   </script>
 </head>
-<body>
+<body id="pageRoot" data-ga-id="G-S5S8LF8NDE">
   <div class="container">
     <!-- Top bar: same minimal nav as home -->
     <header>
@@ -159,4 +152,5 @@
     }
   </script>
 </body>
+<script defer src="/static/script.js?v=2025-08-14-8"></script>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,7 +21,7 @@
   {{ adsense_tag|safe }}
 </head>
 
-<body id="pageRoot" data-paid="{{ '1' if paid else '0' }}" data-job-id="{{ job_id }}">
+<body id="pageRoot" data-ga-id="G-S5S8LF8NDE" data-paid="{{ '1' if paid else '0' }}" data-job-id="{{ job_id }}">
   <div class="container">
     <header>
       <div class="logo">

--- a/app/templates/privacy.html
+++ b/app/templates/privacy.html
@@ -4,13 +4,6 @@
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5S8LF8NDE"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-S5S8LF8NDE');
-  </script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta http-equiv="Cache-Control" content="no-store"/>
@@ -31,7 +24,7 @@
   }
   </script>
 </head>
-<body>
+<body id="pageRoot" data-ga-id="G-S5S8LF8NDE">
   <div class="container">
     <header>
       <div class="logo">
@@ -165,4 +158,5 @@
     }
   </script>
 </body>
+<script defer src="/static/script.js?v=2025-08-14-8"></script>
 </html>

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -3,13 +3,6 @@
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5S8LF8NDE"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-S5S8LF8NDE');
-  </script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Terms & Conditions – MailSized</title>
@@ -18,7 +11,7 @@
 
   {{ adsense_tag|safe }}
 </head>
-<body>
+<body id="pageRoot" data-ga-id="G-S5S8LF8NDE">
   <div class="container">
     <header>
       <div class="logo">
@@ -140,4 +133,5 @@
     }
   </script>
 </body>
+<script defer src="/static/script.js?v=2025-08-14-8"></script>
 </html>


### PR DESCRIPTION
## Summary
- make `/start/{job_id}` idempotent and add `/status/{job_id}` for polling
- log job lifecycle and ffmpeg parameters for easier diagnostics
- add frontend polling fallback and expose GA ID via data attribute, removing inline snippets

## Testing
- `make fmt` *(fails: app/main.py multiple statements on one line)*
- `pytest --cov=app --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68a2629a9844832e8435b2cda08d0a4d