### PR TITLE
fix: prevent ad from overlapping pricing

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -120,6 +120,9 @@ header p{
   border-radius:var(--radius);
   background:var(--card);
   box-shadow:var(--shadow);
+  /* Ensure ad content doesn't overlap pricing details */
+  position:relative;
+  overflow:hidden;
 }
 .ad-placeholder{
   font-size:13px;


### PR DESCRIPTION
## Summary
- keep sidebar ad content from overlapping pricing details

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a2690e0d8c832e8ad826b820f307d9