### PR TITLE
Streamline mini-bill to provider totals

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -301,6 +301,10 @@ header p{
 .pricing-table [data-col].is-selected { background: #f1ecff; font-weight: 600; }
 .pricing-table .sep-row td { border: 0; height: 8px; }
 
+/* Mini-bill totals row emphasis */
+#pricingTotals tbody tr td:first-child { font-weight: 600; color: #2d3748; }
+#pricingTotals tbody tr td:not(:first-child) { font-weight: 600; }
+
 .price-summary{
   border:1px solid var(--border); border-radius: 10px; overflow: hidden;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -212,35 +212,28 @@
                 <td data-col="other">$5.49</td>
               </tr>
             </tbody>
+          </table>
+        </div>
 
-            <!-- Dynamic summary that updates as users pick provider/extras -->
-            <tfoot>
-              <tr class="sep-row"><td colspan="4"></td></tr>
-              <tr id="rowBase">
-                <th>Base (by tier)</th>
-                <td id="tblBase_gmail"   data-col="gmail">$1.99</td>
-                <td id="tblBase_outlook" data-col="outlook">$2.19</td>
-                <td id="tblBase_other"   data-col="other">$2.49</td>
+        <!-- Mini-bill: show only Totals per provider -->
+        <div class="pricing-totals-wrapper" style="margin-top:10px;">
+          <table class="pricing-table" id="pricingTotals" aria-label="Totals by provider">
+            <thead>
+              <tr>
+                <th style="width:120px;">Totals</th>
+                <th>Gmail</th>
+                <th>Outlook</th>
+                <th>Other</th>
               </tr>
-              <tr id="rowUpsells">
-                <th>Extras</th>
-                <td id="tblUpsell_gmail"   data-col="gmail">$0.00</td>
-                <td id="tblUpsell_outlook" data-col="outlook">$0.00</td>
-                <td id="tblUpsell_other"   data-col="other">$0.00</td>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Total</td>
+                <td id="ptTotalGmail">$1.99</td>
+                <td id="ptTotalOutlook">$2.19</td>
+                <td id="ptTotalOther">$2.49</td>
               </tr>
-              <tr id="rowTax">
-                <th>Estimated tax (10%)</th>
-                <td id="tblTax_gmail"   data-col="gmail">$0.00</td>
-                <td id="tblTax_outlook" data-col="outlook">$0.00</td>
-                <td id="tblTax_other"   data-col="other">$0.00</td>
-              </tr>
-              <tr id="rowTotal" class="emph">
-                <th>Total</th>
-                <td id="tblTotal_gmail"   data-col="gmail">$1.99</td>
-                <td id="tblTotal_outlook" data-col="outlook">$2.19</td>
-                <td id="tblTotal_other"   data-col="other">$2.49</td>
-              </tr>
-            </tfoot>
+            </tbody>
           </table>
         </div>
 


### PR DESCRIPTION
## Summary
- Replace mini-bill with a single Totals row for Gmail/Outlook/Other
- Revise calcTotals to fill only the new Total cells and detailed summary
- Emphasize totals with new CSS styling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a292756f28832e81e943f7dbc15488